### PR TITLE
Docs: Align @param tag columns in docblocks

### DIFF
--- a/lib/block-supports/aria-label.php
+++ b/lib/block-supports/aria-label.php
@@ -31,7 +31,7 @@ function gutenberg_register_aria_label_support( $block_type ) {
 /**
  * Add the aria-label to the output.
  *
- * @param WP_Block_Type $block_type Block Type.
+ * @param WP_Block_Type $block_type       Block Type.
  * @param array         $block_attributes Block attributes.
  *
  * @return array Block aria-label.

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -100,8 +100,8 @@ function gutenberg_tinycolor_bound01( $n, $max ) {
  *
  * @deprecated 6.3.0
  *
- * @param  mixed $n   Number of unknown type.
- * @return float      Value in the range [0,1].
+ * @param mixed $n Number of unknown type.
+ * @return float Value in the range [0,1].
  */
 function gutenberg_tinycolor_bound_alpha( $n ) {
 	_deprecated_function( __FUNCTION__, '6.3.0' );
@@ -122,8 +122,8 @@ function gutenberg_tinycolor_bound_alpha( $n ) {
  *
  * @deprecated 6.3.0
  *
- * @param  array $rgb_color RGB object.
- * @return array            Rounded and converted RGB object.
+ * @param array $rgb_color RGB object.
+ * @return array Rounded and converted RGB object.
  */
 function gutenberg_tinycolor_rgb_to_rgb( $rgb_color ) {
 	_deprecated_function( __FUNCTION__, '6.3.0' );
@@ -175,8 +175,8 @@ function gutenberg_tinycolor_hue_to_rgb( $p, $q, $t ) {
  *
  * @deprecated 6.3.0
  *
- * @param  array $hsl_color HSL object.
- * @return array            Rounded and converted RGB object.
+ * @param array $hsl_color HSL object.
+ * @return array Rounded and converted RGB object.
  */
 function gutenberg_tinycolor_hsl_to_rgb( $hsl_color ) {
 	_deprecated_function( __FUNCTION__, '6.3.0' );
@@ -214,8 +214,8 @@ function gutenberg_tinycolor_hsl_to_rgb( $hsl_color ) {
  *
  * @deprecated 6.3.0
  *
- * @param  string $color_str CSS color string.
- * @return array             RGB object.
+ * @param string $color_str CSS color string.
+ * @return array RGB object.
  */
 function gutenberg_tinycolor_string_to_rgb( $color_str ) {
 	_deprecated_function( __FUNCTION__, '6.3.0' );
@@ -371,8 +371,8 @@ function gutenberg_tinycolor_string_to_rgb( $color_str ) {
  *
  * @deprecated 6.3.0
  *
- * @param  array $preset Duotone preset value as seen in theme.json.
- * @return string        Duotone filter CSS id.
+ * @param array $preset Duotone preset value as seen in theme.json.
+ * @return string Duotone filter CSS id.
  */
 function gutenberg_get_duotone_filter_id( $preset ) {
 	_deprecated_function( __FUNCTION__, '6.3.0' );
@@ -384,8 +384,8 @@ function gutenberg_get_duotone_filter_id( $preset ) {
  *
  * @deprecated 6.3.0
  *
- * @param  array $preset Duotone preset value as seen in theme.json.
- * @return string        Duotone CSS filter property url value.
+ * @param array $preset Duotone preset value as seen in theme.json.
+ * @return string Duotone CSS filter property url value.
  */
 function gutenberg_get_duotone_filter_property( $preset ) {
 	_deprecated_function( __FUNCTION__, '6.3.0' );
@@ -397,8 +397,8 @@ function gutenberg_get_duotone_filter_property( $preset ) {
  *
  * @deprecated 6.3.0
  *
- * @param  array $preset Duotone preset value as seen in theme.json.
- * @return string        Duotone SVG filter.
+ * @param array $preset Duotone preset value as seen in theme.json.
+ * @return string Duotone SVG filter.
  */
 function gutenberg_get_duotone_filter_svg( $preset ) {
 	_deprecated_function( __FUNCTION__, '6.3.0' );

--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -10,8 +10,8 @@
  *
  * @deprecated 6.6.0 Use `gutenberg_render_elements_class_name` instead.
  *
- * @param  string $block_content Rendered block content.
- * @return string                Filtered block content.
+ * @param string $block_content Rendered block content.
+ * @return string Filtered block content.
  */
 function gutenberg_render_elements_support( $block_content ) {
 	_deprecated_function( __FUNCTION__, '6.6.0', 'gutenberg_render_elements_class_name' );

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -321,9 +321,9 @@ function gutenberg_sanitize_block_gap_value( $gap_value ) {
 /**
  * Returns child layout styles for a block affected by its parent's layout.
  *
- * @param string     $selector         CSS selector.
- * @param array      $child_layout     Child layout values.
- * @param array      $parent_layout    Parent layout values.
+ * @param string     $selector           CSS selector.
+ * @param array      $child_layout       Child layout values.
+ * @param array      $parent_layout      Parent layout values.
  * @param array|null $viewport_overrides Optional. Child viewport layout overrides to emit.
  * @return array Child layout style rules.
  */
@@ -974,8 +974,8 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
  * but it is unique across the life of the PHP process and it's stable per
  * prefix.
  *
- * @param  string $prefix Prefix for the returned ID.
- * @return string         Incremental ID per prefix.
+ * @param string $prefix Prefix for the returned ID.
+ * @return string Incremental ID per prefix.
  */
 function gutenberg_incremental_id_per_prefix( $prefix = '' ) {
 	static $id_counters = array();
@@ -1603,7 +1603,7 @@ add_filter( 'render_block_core/group', 'gutenberg_restore_group_inner_container'
  * to avoid breaking styles relying on that div.
  *
  * @param string $block_content Rendered block content.
- * @param  array  $block        Block object.
+ * @param array  $block         Block object.
  * @return string Filtered block content.
  */
 function gutenberg_restore_image_outer_container( $block_content, $block ) {

--- a/lib/block-supports/settings.php
+++ b/lib/block-supports/settings.php
@@ -46,8 +46,8 @@ function _gutenberg_add_block_level_presets_class( $block_content, $block ) {
  *
  * @access private
  *
- * @param string|null $pre_render   The pre-rendered content. Default null.
- * @param array       $block The block being rendered.
+ * @param string|null $pre_render The pre-rendered content. Default null.
+ * @param array       $block      The block being rendered.
  *
  * @return null
  */

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -479,7 +479,7 @@ function gutenberg_get_computed_fluid_typography_value( $args = array() ) {
  * @since 6.6.0 Deprecated bool argument $should_use_fluid_typography.
  * @since 6.7.0 Font size presets can enable fluid typography individually, even if it’s disabled globally.
  *
- * @param array $preset       {
+ * @param array      $preset   {
  *     Required. fontSizes preset value as seen in theme.json.
  *
  *     @type string           $name Name of the font size preset.

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -135,8 +135,8 @@ class WP_Duotone_Gutenberg {
 	 * @link https://github.com/omgovich/colord/blob/3f859e03b0ca622eb15480f611371a0f15c9427f/src/helpers.ts#L23
 	 *
 	 * @param float $number The number to clamp.
-	 * @param float $min   The minimum value.
-	 * @param float $max   The maximum value.
+	 * @param float $min    The minimum value.
+	 * @param float $max    The maximum value.
 	 * @return float The clamped value.
 	 */
 	private static function colord_clamp( $number, $min = 0, $max = 1 ) {
@@ -967,8 +967,8 @@ class WP_Duotone_Gutenberg {
 	 *
 	 * @since 6.5.0
 	 *
-	 * @param  string $block_content Rendered block content.
-	 * @return string                Filtered block content.
+	 * @param string $block_content Rendered block content.
+	 * @return string Filtered block content.
 	 */
 	public static function restore_image_outer_container( $block_content ) {
 		if ( wp_theme_has_theme_json() ) {
@@ -1119,8 +1119,8 @@ class WP_Duotone_Gutenberg {
 	 * @since 6.3.0
 	 * @deprecated 6.3.0
 	 *
-	 * @param  array $preset Duotone preset value as seen in theme.json.
-	 * @return string        Duotone filter CSS id.
+	 * @param array $preset Duotone preset value as seen in theme.json.
+	 * @return string Duotone filter CSS id.
 	 */
 	public static function get_filter_id_from_preset( $preset ) {
 		_deprecated_function( __FUNCTION__, '6.3.0' );

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -652,7 +652,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * @since 7.1.0
 	 *
 	 * @param mixed $viewport_settings Viewport settings from theme.json.
-	 * @param array      $options           {
+	 * @param array $options           {
 	 *     Optional. Options for generating media queries.
 	 *
 	 *     @type bool $include_desktop Whether to include the desktop media query. Default false.
@@ -917,11 +917,11 @@ class WP_Theme_JSON_Gutenberg {
 	/**
 	 * Processes pseudo-selectors for any node (block or variation).
 	 *
-	 * @param array  $node The node data (block or variation).
-	 * @param string $base_selector The base selector.
-	 * @param array  $settings The theme settings.
-	 * @param string $block_name The block name.
-	 * @param array|null $block_metadata Metadata about the block to get styles for.
+	 * @param array      $node            The node data (block or variation).
+	 * @param string     $base_selector   The base selector.
+	 * @param array      $settings        The theme settings.
+	 * @param string     $block_name      The block name.
+	 * @param array|null $block_metadata  Metadata about the block to get styles for.
 	 * @param array|null $style_variation Style variation metadata.
 	 * @return array Array of pseudo-selector declarations.
 	 */
@@ -2111,7 +2111,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * Returns the global styles custom CSS for a single block.
 	 * This function is deprecated; please do not sync to core.
 	 *
-	 * @param array  $css The block css node.
+	 * @param array  $css      The block css node.
 	 * @param string $selector The block selector.
 	 *
 	 * @return string The global styles custom CSS for the block.
@@ -3005,13 +3005,13 @@ class WP_Theme_JSON_Gutenberg {
 	 * @since 6.6.0 Passing current theme JSON settings to wp_get_typography_font_size_value(). Using style engine to correctly fetch background CSS values.
 	 * @since 6.7.0 Allow ref resolution of background properties.
 	 *
-	 * @param array   $styles Styles to process.
-	 * @param array   $settings Theme settings.
-	 * @param array   $properties Properties metadata.
-	 * @param array   $theme_json Theme JSON array.
-	 * @param string  $selector The style block selector.
+	 * @param array   $styles           Styles to process.
+	 * @param array   $settings         Theme settings.
+	 * @param array   $properties       Properties metadata.
+	 * @param array   $theme_json       Theme JSON array.
+	 * @param string  $selector         The style block selector.
 	 * @param boolean $use_root_padding Whether to add custom properties at root level.
-	 * @return array  Returns the modified $declarations.
+	 * @return array Returns the modified $declarations.
 	 */
 	protected static function compute_style_properties( $styles, $settings = array(), $properties = null, $theme_json = null, $selector = null, $use_root_padding = null ) {
 		if ( empty( $styles ) ) {
@@ -3137,8 +3137,8 @@ class WP_Theme_JSON_Gutenberg {
 	 * @since 6.1.0 Added the `$theme_json` parameter.
 	 * @since 6.7.0 Added support for background image refs
 	 *
-	 * @param array $styles Styles subtree.
-	 * @param array $path   Which property to process.
+	 * @param array $styles     Styles subtree.
+	 * @param array $path       Which property to process.
 	 * @param array $theme_json Theme JSON array.
 	 * @return string|array Style property value.
 	 */
@@ -3512,7 +3512,7 @@ class WP_Theme_JSON_Gutenberg {
 	 *
 	 * @param array $theme_json The theme.json converted to an array.
 	 * @param array $selectors  Optional list of selectors per block.
-	 * @param array $options {
+	 * @param array $options    {
 	 *     Optional. An array of options for now used for internal purposes only (may change without notice).
 	 *
 	 *     @type bool $include_block_style_variations Includes nodes for block style variations. Default false.
@@ -4601,7 +4601,7 @@ class WP_Theme_JSON_Gutenberg {
 	 *
 	 * @since 5.9.0
 	 *
-	 * @param string $slug The slug we want to find a match from default presets.
+	 * @param string $slug      The slug we want to find a match from default presets.
 	 * @param array  $base_path The path to inspect. It's 'settings' by default.
 	 * @return string|null
 	 */
@@ -4651,8 +4651,8 @@ class WP_Theme_JSON_Gutenberg {
 	 * @since 6.6.0 Added support for block style variation element styles and $origin parameter.
 	 *
 	 * @param array  $theme_json Structure to sanitize.
-	 * @param string $origin    Optional. What source of data this object represents.
-	 *                          One of 'blocks', 'default', 'theme', or 'custom'. Default 'theme'.
+	 * @param string $origin     Optional. What source of data this object represents.
+	 *                           One of 'blocks', 'default', 'theme', or 'custom'. Default 'theme'.
 	 * @return array Sanitized structure.
 	 */
 	public static function remove_insecure_properties( $theme_json, $origin = 'theme' ) {
@@ -5741,7 +5741,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * It is recursive and modifies the input in-place.
 	 *
 	 * @since 6.3.0
-	 * @param array $tree   Input to process.
+	 * @param array $tree Input to process.
 	 * @return array The modified $tree.
 	 */
 	private static function resolve_custom_css_format( $tree ) {
@@ -5891,7 +5891,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * declarations instead of deriving it by subtracting the root selector from
 	 * the feature selector.
 	 *
-	 * @param array  $style_variation Style variation metadata.
+	 * @param array  $style_variation  Style variation metadata.
 	 * @param string $feature_selector CSS selector for the feature.
 	 * @return string Feature selector with block style variation selector added.
 	 */

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -224,7 +224,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 *              Added registration and merging of block style variations from partial theme.json files and the block styles registry.
 	 *
 	 * @param array $deprecated Deprecated. Not used.
-	 * @param array $options {
+	 * @param array $options    {
 	 *     Options arguments.
 	 *
 	 *     @type bool $with_supports Whether to include theme supports in the data. Default true.
@@ -927,7 +927,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 *
 	 * @since 6.6.0
 	 *
-	 * @param array $data   Array following the theme.json specification.
+	 * @param array $data       Array following the theme.json specification.
 	 * @param array $variations Shared block style variations.
 	 * @return array Theme json data including shared block style variation definitions.
 	 */
@@ -969,7 +969,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 *
 	 * @since 6.6.0
 	 *
-	 * @param array $data   Array following the theme.json specification.
+	 * @param array $data Array following the theme.json specification.
 	 * @return array Theme json data including variations from the block styles registry.
 	 */
 	private static function inject_variations_from_block_styles_registry( $data ) {

--- a/lib/class-wp-theme-json-schema-gutenberg.php
+++ b/lib/class-wp-theme-json-schema-gutenberg.php
@@ -105,7 +105,7 @@ class WP_Theme_JSON_Schema_Gutenberg {
 	 *
 	 * @since 6.6.0
 	 *
-	 * @param array $old     Data to migrate.
+	 * @param array  $old    Data to migrate.
 	 * @param string $origin What source of data this object represents.
 	 *                       One of 'blocks', 'default', 'theme', or 'custom'.
 	 * @return array Data with defaultFontSizes set to false.
@@ -219,7 +219,7 @@ class WP_Theme_JSON_Schema_Gutenberg {
 	 * @since 5.9.0
 	 *
 	 * @param array $settings Reference to the current settings array.
-	 * @param array $path Path to the property to be removed.
+	 * @param array $path     Path to the property to be removed.
 	 */
 	private static function unset_setting_by_path( &$settings, $path ) {
 		$tmp_settings = &$settings; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -26,9 +26,9 @@ function gutenberg_dir_path() {
  *
  * @since 0.1.0
  *
- * @param  string $path Relative path of the desired file.
+ * @param string $path Relative path of the desired file.
  *
- * @return string       Fully qualified URL pointing to the desired file.
+ * @return string Fully qualified URL pointing to the desired file.
  */
 function gutenberg_url( $path ) {
 	return plugins_url( $path, __DIR__ );

--- a/lib/compat/wordpress-7.0/template-activate.php
+++ b/lib/compat/wordpress-7.0/template-activate.php
@@ -232,8 +232,8 @@ function gutenberg_get_registered_block_templates( $query ) {
 	 *
 	 * @since 5.9.0
 	 *
-	 * @param WP_Block_Template[] $query_result Array of found block templates.
-	 * @param array               $query {
+	 * @param WP_Block_Template[] $query_result  Array of found block templates.
+	 * @param array               $query         {
 	 *     Arguments to retrieve templates. All arguments are optional.
 	 *
 	 *     @type string[] $slug__in  List of slugs to include.
@@ -827,8 +827,8 @@ function gutenberg_get_block_templates( $output, $query = array(), $template_typ
 	 *
 	 * @since 5.9.0
 	 *
-	 * @param WP_Block_Template[] $query_result Array of found block templates.
-	 * @param array               $query {
+	 * @param WP_Block_Template[] $query_result  Array of found block templates.
+	 * @param array               $query         {
 	 *     Arguments to retrieve templates. All arguments are optional.
 	 *
 	 *     @type string[] $slug__in  List of slugs to include.

--- a/lib/compat/wordpress-7.1/icons.php
+++ b/lib/compat/wordpress-7.1/icons.php
@@ -44,7 +44,7 @@ if ( ! function_exists( 'wp_register_icon' ) ) {
 	 *                          reserved for WordPress core icons; third-party code should
 	 *                          register icons under its own collection rather than the
 	 *                          "core" collection.
-	 * @param array  $args {
+	 * @param array  $args      {
 	 *     List of properties for the icon.
 	 *
 	 *     @type string $label     Required. A human-readable label for the icon.

--- a/lib/compat/wordpress-7.1/query-block.php
+++ b/lib/compat/wordpress-7.1/query-block.php
@@ -8,7 +8,7 @@
 /**
  * Filters the query loop block query vars to exclude the current post.
  *
- * @param array $query The current query vars.
+ * @param array    $query The current query vars.
  * @param WP_Block $block The block instance.
  *
  * @return array The modified query vars.

--- a/lib/experimental/kses.php
+++ b/lib/experimental/kses.php
@@ -79,7 +79,7 @@ if ( ! function_exists( 'allow_filter_in_styles' ) ) {
 	 *
 	 * This function should not be backported to core.
 	 *
-	 * @param bool   $allow_css Whether the CSS is allowed.
+	 * @param bool   $allow_css       Whether the CSS is allowed.
 	 * @param string $css_test_string The CSS to test.
 	 * @return bool Whether the CSS is allowed.
 	 */

--- a/lib/experimental/navigation-theme-opt-in.php
+++ b/lib/experimental/navigation-theme-opt-in.php
@@ -177,7 +177,7 @@ add_filter( 'wp_nav_menu_objects', 'gutenberg_remove_block_nav_menu_items', 10 )
  * Transformation depends on the menu item type. Link menu items are turned into
  * a `core/navigation-link` block. Block menu items are simply parsed.
  *
- * @param array $menu_items The menu items to convert, sorted by each menu item's menu order.
+ * @param array $menu_items              The menu items to convert, sorted by each menu item's menu order.
  * @param array $menu_items_by_parent_id All menu items, indexed by their parent's ID.
  *
  * @return array Updated menu items, sorted by each menu item's menu order.

--- a/lib/media/class-gutenberg-rest-attachments-controller.php
+++ b/lib/media/class-gutenberg-rest-attachments-controller.php
@@ -1756,8 +1756,8 @@ class Gutenberg_REST_Attachments_Controller extends WP_REST_Attachments_Controll
 	 * https://github.com/WordPress/wordpress-develop/pull/11856; until it lands
 	 * the function_exists() guard falls back to the inline implementation below.
 	 *
-	 * @param non-empty-string $mime_type The output image MIME type, e.g. 'image/jpeg'.
-	 * @param array{ width?: non-negative-int, height?: non-negative-int } $size Dimensions ('width', 'height') for the wp_editor_set_quality filter.
+	 * @param non-empty-string                                             $mime_type The output image MIME type, e.g. 'image/jpeg'.
+	 * @param array{ width?: non-negative-int, height?: non-negative-int } $size      Dimensions ('width', 'height') for the wp_editor_set_quality filter.
 	 * @return int<1, 100> Encode quality between 1 and 100.
 	 */
 	private function get_image_encode_quality( string $mime_type, array $size = array() ): int {

--- a/packages/block-library/src/accordion-item/index.php
+++ b/packages/block-library/src/accordion-item/index.php
@@ -7,7 +7,7 @@
  * @since 6.9.0
  *
  * @param array{ openByDefault: bool } $attributes The block attributes.
- * @param string                        $content   The block content.
+ * @param string                       $content    The block content.
  * @return string Returns the updated markup.
  */
 function block_core_accordion_item_render( array $attributes, string $content ): string {

--- a/packages/block-library/src/accordion/index.php
+++ b/packages/block-library/src/accordion/index.php
@@ -5,8 +5,8 @@
  * @package WordPress
  * @since 6.9.0
  *
- * @param array $attributes The block attributes.
- * @param string $content The block content.
+ * @param array  $attributes The block attributes.
+ * @param string $content    The block content.
  *
  * @return string Returns the updated markup.
  */

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -298,7 +298,7 @@ function block_core_breadcrumbs_get_post_title( $post_id_or_object ) {
  *
  * @since 7.0.0
  *
- * @param int    $post_id   The post ID.
+ * @param int $post_id The post ID.
  *
  * @return array Array of breadcrumb item data.
  */
@@ -524,7 +524,7 @@ function block_core_breadcrumbs_get_terms_breadcrumbs( $post_id, $post_type ) {
 	 *
 	 * @since 7.0.0
 	 *
-	 * @param array  $settings {
+	 * @param array  $settings  {
 	 *     Array of breadcrumb settings. Default empty array.
 	 *
 	 *     @type string $taxonomy Optional. Taxonomy slug to use for breadcrumbs.

--- a/packages/block-library/src/form-input/index.php
+++ b/packages/block-library/src/form-input/index.php
@@ -9,7 +9,7 @@
  * Renders the `core/form-input` block on server.
  *
  * @param array  $attributes The block attributes.
- * @param string $content The saved content.
+ * @param string $content    The saved content.
  *
  * @return string The content of the block being rendered.
  */

--- a/packages/block-library/src/form-submission-notification/index.php
+++ b/packages/block-library/src/form-submission-notification/index.php
@@ -9,7 +9,7 @@
  * Renders the `core/form-submission-notification` block on server.
  *
  * @param array  $attributes The block attributes.
- * @param string $content The saved content.
+ * @param string $content    The saved content.
  *
  * @return string The content of the block being rendered.
  */

--- a/packages/block-library/src/form/index.php
+++ b/packages/block-library/src/form/index.php
@@ -9,7 +9,7 @@
  * Renders the `core/form` block on server.
  *
  * @param array  $attributes The block attributes.
- * @param string $content The saved content.
+ * @param string $content    The saved content.
  *
  * @return string The content of the block being rendered.
  */

--- a/packages/block-library/src/heading/index.php
+++ b/packages/block-library/src/heading/index.php
@@ -17,7 +17,7 @@
  * @since 6.2.0
  *
  * @param array  $attributes Attributes of the block being rendered.
- * @param string $content Content of the block being rendered.
+ * @param string $content    Content of the block being rendered.
  *
  * @return string The content of the block being rendered.
  */

--- a/packages/block-library/src/home-link/index.php
+++ b/packages/block-library/src/home-link/index.php
@@ -11,7 +11,7 @@
  *
  * @since 6.0.0
  *
- * @param  array $context home link block context.
+ * @param array $context home link block context.
  * @return array Colors CSS classes and inline styles.
  */
 function block_core_home_link_build_css_colors( $context ) {
@@ -64,7 +64,7 @@ function block_core_home_link_build_css_colors( $context ) {
  *
  * @since 6.0.0
  *
- * @param  array $context    Home link block context.
+ * @param array $context Home link block context.
  * @return string The li wrapper attributes.
  */
 function block_core_home_link_build_li_wrapper_attributes( $context ) {

--- a/packages/block-library/src/list/index.php
+++ b/packages/block-library/src/list/index.php
@@ -15,7 +15,7 @@
  * @see https://github.com/WordPress/gutenberg/issues/12420
  *
  * @param array  $attributes Attributes of the block being rendered.
- * @param string $content Content of the block being rendered.
+ * @param string $content    Content of the block being rendered.
  *
  * @return string The content of the block being rendered.
  */

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -90,7 +90,7 @@ function block_core_navigation_link_build_css_colors( $context, $attributes, $is
  * @since 5.9.0
  * @deprecated 7.0.0
  *
- * @param  array $context Navigation block context.
+ * @param array $context Navigation block context.
  * @return array Font size CSS classes and inline styles.
  */
 function block_core_navigation_link_build_css_font_sizes( $context ) {
@@ -308,7 +308,7 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
  * @since 5.9.0
  *
  * @param WP_Taxonomy|WP_Post_Type $entity post type or taxonomy entity.
- * @param string                   $kind string of value 'taxonomy' or 'post-type'.
+ * @param string                   $kind   string of value 'taxonomy' or 'post-type'.
  *
  * @return array
  */

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -411,7 +411,7 @@ class WP_Navigation_Block_Renderer {
 	 * @since 6.5.0
 	 *
 	 * @param string $overlay_template_part_id The overlay template part ID in format "theme//slug".
-	 * @param array  $attributes                The block attributes.
+	 * @param array  $attributes               The block attributes.
 	 * @return WP_Block_List Returns the inner blocks for the overlay template part.
 	 */
 	private static function get_overlay_blocks_from_template_part( $overlay_template_part_id, $attributes ) {
@@ -512,7 +512,7 @@ class WP_Navigation_Block_Renderer {
 	 * @since 6.5.0
 	 *
 	 * @param array    $attributes The block attributes.
-	 * @param WP_Block $block The parsed block.
+	 * @param WP_Block $block      The parsed block.
 	 * @return WP_Block_List Returns the inner blocks for the navigation block.
 	 */
 	private static function get_inner_blocks( $attributes, $block ) {
@@ -734,8 +734,8 @@ class WP_Navigation_Block_Renderer {
 	 *
 	 * @since 6.5.0
 	 *
-	 * @param array         $attributes The block attributes.
-	 * @param WP_Block_List $inner_blocks The list of inner blocks.
+	 * @param array         $attributes        The block attributes.
+	 * @param WP_Block_List $inner_blocks      The list of inner blocks.
 	 * @param string        $inner_blocks_html The markup for the inner blocks.
 	 * @return string Returns the container markup.
 	 */
@@ -973,7 +973,7 @@ class WP_Navigation_Block_Renderer {
 	 *
 	 * @since 6.5.0
 	 *
-	 * @param array         $attributes The block attributes.
+	 * @param array         $attributes   The block attributes.
 	 * @param WP_Block_List $inner_blocks The list of inner blocks.
 	 * @return string Returns the navigation wrapper markup.
 	 */
@@ -1885,7 +1885,7 @@ function block_core_navigation_get_classic_menu_fallback() {
  *
  * @deprecated 6.3.0 Use WP_Navigation_Fallback::get_classic_menu_fallback_blocks() instead.
  *
- * @param  object $classic_nav_menu WP_Term The classic navigation object to convert.
+ * @param object $classic_nav_menu WP_Term The classic navigation object to convert.
  * @return array the normalized parsed blocks.
  */
 function block_core_navigation_get_classic_menu_fallback_blocks( $classic_nav_menu ) {

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -128,14 +128,14 @@ function block_core_page_list_build_css_colors( $attributes, $context ) {
  *
  * @since 5.8.0
  *
- * @param string  $submenu_visibility The submenu visibility mode: 'hover', 'click', or 'always'.
- * @param boolean $show_submenu_icons Whether to show submenu indicator icons.
- * @param boolean $is_navigation_child If block is a child of Navigation block.
- * @param array   $nested_pages The array of nested pages.
- * @param boolean $is_nested Whether the submenu is nested or not.
+ * @param string  $submenu_visibility       The submenu visibility mode: 'hover', 'click', or 'always'.
+ * @param boolean $show_submenu_icons       Whether to show submenu indicator icons.
+ * @param boolean $is_navigation_child      If block is a child of Navigation block.
+ * @param array   $nested_pages             The array of nested pages.
+ * @param boolean $is_nested                Whether the submenu is nested or not.
  * @param array   $active_page_ancestor_ids An array of ancestor ids for active page.
- * @param array   $colors Color information for overlay styles.
- * @param integer $depth The nesting depth.
+ * @param array   $colors                   Color information for overlay styles.
+ * @param integer $depth                    The nesting depth.
  *
  * @return string List markup.
  */
@@ -227,7 +227,7 @@ function block_core_page_list_render_nested_page_list( $submenu_visibility, $sho
  * @since 5.8.0
  *
  * @param array $current_level The level being iterated through.
- * @param array $children The children grouped by parent post ID.
+ * @param array $children      The children grouped by parent post ID.
  *
  * @return array The nested array of pages.
  */

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -360,7 +360,7 @@ function apply_block_core_search_border_styles( $attributes, $property, &$wrappe
  *
  * @since 5.8.0
  *
- * @param  array $attributes The block attributes.
+ * @param array $attributes The block attributes.
  *
  * @return array Style HTML attribute.
  */

--- a/packages/block-library/src/site-logo/index.php
+++ b/packages/block-library/src/site-logo/index.php
@@ -139,7 +139,7 @@ add_filter( 'theme_mod_custom_logo', '_override_custom_logo_theme_mod' );
  *
  * @since 5.8.0
  *
- * @param  mixed $value Attachment ID of the custom logo or an empty value.
+ * @param mixed $value Attachment ID of the custom logo or an empty value.
  * @return mixed
  */
 function _sync_custom_logo_to_site_logo( $value ) {

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -138,7 +138,7 @@ function block_core_social_link_get_name( $service ) {
  * @since 5.4.0
  *
  * @param string $service The service slug to extract data from.
- * @param string $field The field ('name', 'icon', etc) to extract for a service.
+ * @param string $field   The field ('name', 'icon', etc) to extract for a service.
  *
  * @return array|string
  */

--- a/packages/block-library/src/table-of-contents/index.php
+++ b/packages/block-library/src/table-of-contents/index.php
@@ -14,7 +14,7 @@ const BLOCK_CORE_TABLE_OF_CONTENTS_DEFAULT_HEADING_LEVEL = 2;
  * Adds an aria-label to the table of contents block content.
  *
  * @param array  $attributes Attributes of the block being rendered.
- * @param string $content Content of the block being rendered.
+ * @param string $content    Content of the block being rendered.
  *
  * @return string The content of the block being rendered.
  */
@@ -364,8 +364,8 @@ function block_core_table_of_contents_build_list_items( $nested_headings, $list_
  * Renders the table of contents block from current post headings.
  *
  * @param array         $attributes Attributes of the block being rendered.
- * @param string        $content Content of the block being rendered.
- * @param WP_Block|null $block Block instance.
+ * @param string        $content    Content of the block being rendered.
+ * @param WP_Block|null $block      Block instance.
  *
  * @return string The content of the block being rendered.
  */

--- a/packages/e2e-tests/plugins/class-test-widget.php
+++ b/packages/e2e-tests/plugins/class-test-widget.php
@@ -25,7 +25,7 @@ class Test_Widget extends WP_Widget {
 	/**
 	 * Outputs the content for the widget instance.
 	 *
-	 * @param array $args Display arguments including 'before_title', 'after_title',
+	 * @param array $args     Display arguments including 'before_title', 'after_title',
 	 *                        'before_widget', and 'after_widget'.
 	 * @param array $instance Settings for the current Block widget instance.
 	 */

--- a/packages/style-engine/src/class-wp-style-engine-processor.php
+++ b/packages/style-engine/src/class-wp-style-engine-processor.php
@@ -97,7 +97,7 @@ if ( ! class_exists( 'WP_Style_Engine_Processor' ) ) {
 		 *
 		 * Since 6.4.0 Optimization is no longer the default.
 		 *
-		 * @param array $options   {
+		 * @param array $options {
 		 *     Optional. An array of options. Default empty array.
 		 *
 		 *     @type bool $optimize Whether to optimize the CSS output, e.g., combine rules. Default is `false`.

--- a/packages/style-engine/src/class-wp-style-engine.php
+++ b/packages/style-engine/src/class-wp-style-engine.php
@@ -404,7 +404,7 @@ if ( ! class_exists( 'WP_Style_Engine' ) ) {
 		/**
 		 * Util: Checks whether an incoming block style value is valid.
 		 *
-		 * @param string? $style_value  A single css preset value.
+		 * @param string? $style_value A single css preset value.
 		 *
 		 * @return bool
 		 */
@@ -415,11 +415,11 @@ if ( ! class_exists( 'WP_Style_Engine' ) ) {
 		/**
 		 * Stores a CSS rule using the provided CSS selector and CSS declarations.
 		 *
-		 * @param string   $store_name       A valid store key.
-		 * @param string   $css_selector     When a selector is passed, the function will return a full CSS rule `$selector { ...rules }`, otherwise a concatenated string of properties and values.
+		 * @param string                                    $store_name       A valid store key.
+		 * @param string                                    $css_selector     When a selector is passed, the function will return a full CSS rule `$selector { ...rules }`, otherwise a concatenated string of properties and values.
 		 * @param string[]|WP_Style_Engine_CSS_Declarations $css_declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ),
-		 *                                                                     or a WP_Style_Engine_CSS_Declarations object.
-		 * @param string   $rules_group        Optional. A parent CSS selector in the case of nested CSS, or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
+		 *                                                                    or a WP_Style_Engine_CSS_Declarations object.
+		 * @param string                                    $rules_group      Optional. A parent CSS selector in the case of nested CSS, or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
 		 *
 		 * @return void.
 		 */

--- a/packages/style-engine/src/style-engine.php
+++ b/packages/style-engine/src/style-engine.php
@@ -22,7 +22,7 @@
  * @since 6.1.0
  *
  * @param array $block_styles The style object.
- * @param array $options {
+ * @param array $options      {
  *     Optional. An array of options. Default empty array.
  *
  *     @type string|null $context                    An identifier describing the origin of the style object, e.g., 'block-supports' or 'global-styles'. Default is `null`.
@@ -89,7 +89,7 @@ function wp_style_engine_get_styles( $block_styles, $options = array() ) {
  *                                                                       or a WP_Style_Engine_CSS_Declarations object.
  *     }
  * }
- * @param array $options {
+ * @param array $options   {
  *     Optional. An array of options. Default empty array.
  *
  *     @type string|null $context  An identifier describing the origin of the style object, e.g., 'block-supports' or 'global-styles'. Default is 'block-supports'.

--- a/packages/widgets/src/blocks/widget-group/index.php
+++ b/packages/widgets/src/blocks/widget-group/index.php
@@ -14,8 +14,8 @@
  * @global int|string $_sidebar_being_rendered
  *
  * @param array    $attributes The block attributes.
- * @param string   $content The block content.
- * @param WP_Block $block The block.
+ * @param string   $content    The block content.
+ * @param WP_Block $block      The block.
  *
  * @return string Rendered block.
  */
@@ -70,7 +70,7 @@ add_action( 'init', 'register_block_core_widget_group' );
  *
  * @global int|string $_sidebar_being_rendered
  *
- * @param int|string $index       Index, name, or ID of the dynamic sidebar.
+ * @param int|string $index Index, name, or ID of the dynamic sidebar.
  */
 function note_sidebar_being_rendered( $index ) {
 	global $_sidebar_being_rendered;

--- a/phpunit/block-supports/aria-label-test.php
+++ b/phpunit/block-supports/aria-label-test.php
@@ -48,8 +48,8 @@ class WP_Block_Supports_Aria_Label_Test extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_aria_label_block_support
 	 *
-	 * @param boolean|array $support Aria label block support configuration.
-	 * @param string        $value   Aria label value for attribute object.
+	 * @param boolean|array $support  Aria label block support configuration.
+	 * @param string        $value    Aria label value for attribute object.
 	 * @param array         $expected Expected aria-label attributes.
 	 */
 	public function test_gutenberg_apply_aria_label_support( $support, $value, $expected ) {

--- a/phpunit/block-supports/shadow-test.php
+++ b/phpunit/block-supports/shadow-test.php
@@ -55,9 +55,9 @@ class WP_Block_Supports_Shadow_Test extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_generate_shadow_fixtures
 	 *
-	 * @param boolean|array $support Shadow block support configuration.
-	 * @param string        $value   Shadow style value for style attribute object.
-	 * @param array         $expected       Expected shadow block support styles.
+	 * @param boolean|array $support  Shadow block support configuration.
+	 * @param string        $value    Shadow style value for style attribute object.
+	 * @param array         $expected Expected shadow block support styles.
 	 */
 	public function test_gutenberg_apply_shadow_support( $support, $value, $expected ) {
 		$block_type  = self::register_shadow_block_with_support(

--- a/phpunit/block-supports/states-test.php
+++ b/phpunit/block-supports/states-test.php
@@ -63,8 +63,8 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 	 * to produce the unique scoped class name for a given map of state => style arrays.
 	 * CSS is now registered with the style engine store rather than injected inline.
 	 *
-	 * @param array $state_styles Map of state to style array (e.g. `[':hover' => ['color' => [...]]]`).
-	 * @param string $block_name  Block name.
+	 * @param array  $state_styles Map of state to style array (e.g. `[':hover' => ['color' => [...]]]`).
+	 * @param string $block_name   Block name.
 	 * @return array { unique_class: string }
 	 */
 	private function build_expected_state_output( $state_styles, $block_name = 'core/navigation-link' ) {

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -292,7 +292,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_generate_font_size_preset_fixtures
 	 *
-	 * @param array  $font_size                     {
+	 * @param array  $font_size       {
 	 *     Required. A font size as represented in the fontSizes preset format as seen in theme.json.
 	 *
 	 *     @type string $name Name of the font size preset.
@@ -810,7 +810,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_generate_font_size_preset_should_use_fluid_typography_deprecated_fixtures
 	 *
-	 * @param array  $font_size                     {
+	 * @param array  $font_size                   {
 	 *     Required. A font size as represented in the fontSizes preset format as seen in theme.json.
 	 *
 	 *     @type string $name Name of the font size preset.
@@ -818,7 +818,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	 *     @type string $size CSS font-size value, including units where applicable.
 	 * }
 	 * @param bool   $should_use_fluid_typography An override to switch fluid typography "on". Can be used for unit testing.
-	 * @param string $expected_output Expected output of gutenberg_get_typography_font_size_value().
+	 * @param string $expected_output             Expected output of gutenberg_get_typography_font_size_value().
 	 */
 	public function test_gutenberg_get_typography_font_size_value_should_use_fluid_typography_deprecated( $font_size, $should_use_fluid_typography, $expected_output ) {
 		$actual = gutenberg_get_typography_font_size_value( $font_size, $should_use_fluid_typography );
@@ -858,7 +858,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_generate_should_override_theme_settings_fixtures
 	 *
-	 * @param array  $font_size                     {
+	 * @param array  $font_size       {
 	 *     Required. A font size as represented in the fontSizes preset format as seen in theme.json.
 	 *
 	 *     @type string $name Name of the font size preset.
@@ -1241,7 +1241,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_get_computed_fluid_typography_value
 	 *
-	 * @param array  $args {
+	 * @param array  $args            {
 	 *      Optional. An associative array of values to calculate a fluid formula for font size. Default is empty array.
 	 *
 	 *     @type string $maximum_viewport_width Maximum size up to which type will have fluidity.
@@ -1250,7 +1250,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	 *     @type string $minimum_font_size      Minimum font size for any clamp() calculation.
 	 *     @type int    $scale_factor           A scale factor to determine how fast a font scales within boundaries.
 	 * }
-	 * @param string $expected_output             Expected value of style property from gutenberg_apply_typography_support().
+	 * @param string $expected_output Expected value of style property from gutenberg_apply_typography_support().
 	 */
 	public function test_get_computed_fluid_typography_value( $args, $expected_output ) {
 		$actual = gutenberg_get_computed_fluid_typography_value( $args );

--- a/phpunit/blocks/block-navigation-link-variations-test.php
+++ b/phpunit/blocks/block-navigation-link-variations-test.php
@@ -244,7 +244,7 @@ class Block_Navigation_Link_Variations_Test extends WP_UnitTestCase {
 	 * Get a variation by its name from an array of variations.
 	 *
 	 * @param string $variation_name The name (= slug) of the variation.
-	 * @param array  $variations An array of variations.
+	 * @param array  $variations     An array of variations.
 	 * @return array|null The found variation or null.
 	 */
 	private function get_variation_by_name( $variation_name, $variations ) {

--- a/phpunit/class-wp-theme-json-selector-list.php
+++ b/phpunit/class-wp-theme-json-selector-list.php
@@ -12,7 +12,7 @@ class WP_Theme_JSON_Gutenberg_Selector_List_Test extends WP_UnitTestCase {
 	 * Invokes a protected static method on WP_Theme_JSON_Gutenberg.
 	 *
 	 * @param string $method_name Method name.
-	 * @param mixed ...$args Method arguments.
+	 * @param mixed  ...$args     Method arguments.
 	 * @return mixed Method result.
 	 */
 	private static function invoke_theme_json_method( $method_name, ...$args ) {
@@ -29,7 +29,7 @@ class WP_Theme_JSON_Gutenberg_Selector_List_Test extends WP_UnitTestCase {
 	/**
 	 * @dataProvider data_split_selector_list
 	 *
-	 * @param string $selector CSS selector list.
+	 * @param string   $selector CSS selector list.
 	 * @param string[] $expected Expected selectors.
 	 */
 	public function test_split_selector_list( $selector, $expected ) {

--- a/phpunit/notes-mentions-test.php
+++ b/phpunit/notes-mentions-test.php
@@ -80,8 +80,8 @@ class Tests_Notes_Mentions extends WP_UnitTestCase {
 	/**
 	 * Records wp_mail() calls and short-circuits delivery.
 	 *
-	 * @param null                                              $short_circuit Short-circuit value.
-	 * @param array{ to: string|string[], subject: string, message: string } $atts wp_mail() arguments.
+	 * @param null                                                           $short_circuit Short-circuit value.
+	 * @param array{ to: string|string[], subject: string, message: string } $atts          wp_mail() arguments.
 	 * @return bool Always true to indicate a "sent" message.
 	 */
 	public function capture_mail( $short_circuit, $atts ): bool {

--- a/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/CodeAnalysis/ForbiddenFunctionsAndClassesSniff.php
+++ b/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/CodeAnalysis/ForbiddenFunctionsAndClassesSniff.php
@@ -65,8 +65,8 @@ final class ForbiddenFunctionsAndClassesSniff implements Sniff {
 	 * Detects whether a given string token represents a function call or class usage.
 	 * It then delegates further processing based on the type of usage detected.
 	 *
-	 * @param File $phpcs_file The file being scanned.
-	 * @param int  $stack_pointer  The position of the current token in the token stack.
+	 * @param File $phpcs_file    The file being scanned.
+	 * @param int  $stack_pointer The position of the current token in the token stack.
 	 */
 	private function process_string_token( File $phpcs_file, $stack_pointer ) {
 		if ( empty( $this->forbidden_functions ) && empty( $this->forbidden_classes ) ) {


### PR DESCRIPTION
## What?

Aligns the type, variable name, and description columns of `@param` tags in PHP docblocks so they follow the [WordPress PHP documentation standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/).

## Why?

61 docblocks had `@param` columns that did not line up, and a further 24 lone `@param` tags carried stray padding (`@param  string $path`). The project's `phpcs.xml.dist` does not include `Squiz.Commenting.FunctionComment`, so CI never flagged any of it.

## How?

- Pads the type and `$var` columns to the widest entry within each docblock and normalises separators to a single space.
- Collapses stray padding on lone `@param` tags.
- Re-indents wrapped description lines to follow their new column.
- Removes `@return` padding left orphaned by the above, in the same docblocks.

Deliberately preserved:

- Hash-notation bodies (`{ ... }`) keep their fixed four-space indent rather than tracking the description column.
- Types containing spaces (`array<int, mixed>`, `array{ width?: non-negative-int }`) are kept as written.
- `@return` tags outside the touched docblocks are untouched — WordPress aligns those independently of `@param`.

## Testing Instructions

This is a comment-only change; no runtime behaviour is affected.

```bash
vendor/bin/phpcs -s --standard=WordPress-Docs \
  --sniffs=Squiz.Commenting.FunctionComment $(git diff --name-only trunk)
```

Verified on this branch:

| Check | Result |
|---|---|
| `WordPress-Docs` param-alignment sniffs | 0 violations (5 in sampled files before) |
| `vendor/bin/phpcs` (project ruleset) | 0 errors |
| `php -l` on all 46 files | clean |
| `git diff --check` | clean |
| `npm run build` | passes |

Every changed line sits inside a docblock, and the diff is exactly balanced at 136 insertions / 136 deletions.

## Note

No `CHANGELOG.md` entries added — these are docblock comments, not production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)