### PR TITLE
Docs: Align @param tag columns in lib/ docblocks

### DIFF
--- a/lib/block-supports/aria-label.php
+++ b/lib/block-supports/aria-label.php
@@ -31,7 +31,7 @@ function gutenberg_register_aria_label_support( $block_type ) {
 /**
  * Add the aria-label to the output.
  *
- * @param WP_Block_Type $block_type Block Type.
+ * @param WP_Block_Type $block_type       Block Type.
  * @param array         $block_attributes Block attributes.
  *
  * @return array Block aria-label.

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -100,8 +100,8 @@ function gutenberg_tinycolor_bound01( $n, $max ) {
  *
  * @deprecated 6.3.0
  *
- * @param  mixed $n   Number of unknown type.
- * @return float      Value in the range [0,1].
+ * @param mixed $n Number of unknown type.
+ * @return float Value in the range [0,1].
  */
 function gutenberg_tinycolor_bound_alpha( $n ) {
 	_deprecated_function( __FUNCTION__, '6.3.0' );
@@ -122,8 +122,8 @@ function gutenberg_tinycolor_bound_alpha( $n ) {
  *
  * @deprecated 6.3.0
  *
- * @param  array $rgb_color RGB object.
- * @return array            Rounded and converted RGB object.
+ * @param array $rgb_color RGB object.
+ * @return array Rounded and converted RGB object.
  */
 function gutenberg_tinycolor_rgb_to_rgb( $rgb_color ) {
 	_deprecated_function( __FUNCTION__, '6.3.0' );
@@ -175,8 +175,8 @@ function gutenberg_tinycolor_hue_to_rgb( $p, $q, $t ) {
  *
  * @deprecated 6.3.0
  *
- * @param  array $hsl_color HSL object.
- * @return array            Rounded and converted RGB object.
+ * @param array $hsl_color HSL object.
+ * @return array Rounded and converted RGB object.
  */
 function gutenberg_tinycolor_hsl_to_rgb( $hsl_color ) {
 	_deprecated_function( __FUNCTION__, '6.3.0' );
@@ -214,8 +214,8 @@ function gutenberg_tinycolor_hsl_to_rgb( $hsl_color ) {
  *
  * @deprecated 6.3.0
  *
- * @param  string $color_str CSS color string.
- * @return array             RGB object.
+ * @param string $color_str CSS color string.
+ * @return array RGB object.
  */
 function gutenberg_tinycolor_string_to_rgb( $color_str ) {
 	_deprecated_function( __FUNCTION__, '6.3.0' );
@@ -371,8 +371,8 @@ function gutenberg_tinycolor_string_to_rgb( $color_str ) {
  *
  * @deprecated 6.3.0
  *
- * @param  array $preset Duotone preset value as seen in theme.json.
- * @return string        Duotone filter CSS id.
+ * @param array $preset Duotone preset value as seen in theme.json.
+ * @return string Duotone filter CSS id.
  */
 function gutenberg_get_duotone_filter_id( $preset ) {
 	_deprecated_function( __FUNCTION__, '6.3.0' );
@@ -384,8 +384,8 @@ function gutenberg_get_duotone_filter_id( $preset ) {
  *
  * @deprecated 6.3.0
  *
- * @param  array $preset Duotone preset value as seen in theme.json.
- * @return string        Duotone CSS filter property url value.
+ * @param array $preset Duotone preset value as seen in theme.json.
+ * @return string Duotone CSS filter property url value.
  */
 function gutenberg_get_duotone_filter_property( $preset ) {
 	_deprecated_function( __FUNCTION__, '6.3.0' );
@@ -397,8 +397,8 @@ function gutenberg_get_duotone_filter_property( $preset ) {
  *
  * @deprecated 6.3.0
  *
- * @param  array $preset Duotone preset value as seen in theme.json.
- * @return string        Duotone SVG filter.
+ * @param array $preset Duotone preset value as seen in theme.json.
+ * @return string Duotone SVG filter.
  */
 function gutenberg_get_duotone_filter_svg( $preset ) {
 	_deprecated_function( __FUNCTION__, '6.3.0' );

--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -10,8 +10,8 @@
  *
  * @deprecated 6.6.0 Use `gutenberg_render_elements_class_name` instead.
  *
- * @param  string $block_content Rendered block content.
- * @return string                Filtered block content.
+ * @param string $block_content Rendered block content.
+ * @return string Filtered block content.
  */
 function gutenberg_render_elements_support( $block_content ) {
 	_deprecated_function( __FUNCTION__, '6.6.0', 'gutenberg_render_elements_class_name' );

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -321,9 +321,9 @@ function gutenberg_sanitize_block_gap_value( $gap_value ) {
 /**
  * Returns child layout styles for a block affected by its parent's layout.
  *
- * @param string     $selector         CSS selector.
- * @param array      $child_layout     Child layout values.
- * @param array      $parent_layout    Parent layout values.
+ * @param string     $selector           CSS selector.
+ * @param array      $child_layout       Child layout values.
+ * @param array      $parent_layout      Parent layout values.
  * @param array|null $viewport_overrides Optional. Child viewport layout overrides to emit.
  * @return array Child layout style rules.
  */
@@ -974,8 +974,8 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
  * but it is unique across the life of the PHP process and it's stable per
  * prefix.
  *
- * @param  string $prefix Prefix for the returned ID.
- * @return string         Incremental ID per prefix.
+ * @param string $prefix Prefix for the returned ID.
+ * @return string Incremental ID per prefix.
  */
 function gutenberg_incremental_id_per_prefix( $prefix = '' ) {
 	static $id_counters = array();
@@ -1603,7 +1603,7 @@ add_filter( 'render_block_core/group', 'gutenberg_restore_group_inner_container'
  * to avoid breaking styles relying on that div.
  *
  * @param string $block_content Rendered block content.
- * @param  array  $block        Block object.
+ * @param array  $block         Block object.
  * @return string Filtered block content.
  */
 function gutenberg_restore_image_outer_container( $block_content, $block ) {

--- a/lib/block-supports/settings.php
+++ b/lib/block-supports/settings.php
@@ -46,8 +46,8 @@ function _gutenberg_add_block_level_presets_class( $block_content, $block ) {
  *
  * @access private
  *
- * @param string|null $pre_render   The pre-rendered content. Default null.
- * @param array       $block The block being rendered.
+ * @param string|null $pre_render The pre-rendered content. Default null.
+ * @param array       $block      The block being rendered.
  *
  * @return null
  */

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -479,7 +479,7 @@ function gutenberg_get_computed_fluid_typography_value( $args = array() ) {
  * @since 6.6.0 Deprecated bool argument $should_use_fluid_typography.
  * @since 6.7.0 Font size presets can enable fluid typography individually, even if it’s disabled globally.
  *
- * @param array $preset       {
+ * @param array      $preset   {
  *     Required. fontSizes preset value as seen in theme.json.
  *
  *     @type string           $name Name of the font size preset.

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -135,8 +135,8 @@ class WP_Duotone_Gutenberg {
 	 * @link https://github.com/omgovich/colord/blob/3f859e03b0ca622eb15480f611371a0f15c9427f/src/helpers.ts#L23
 	 *
 	 * @param float $number The number to clamp.
-	 * @param float $min   The minimum value.
-	 * @param float $max   The maximum value.
+	 * @param float $min    The minimum value.
+	 * @param float $max    The maximum value.
 	 * @return float The clamped value.
 	 */
 	private static function colord_clamp( $number, $min = 0, $max = 1 ) {
@@ -967,8 +967,8 @@ class WP_Duotone_Gutenberg {
 	 *
 	 * @since 6.5.0
 	 *
-	 * @param  string $block_content Rendered block content.
-	 * @return string                Filtered block content.
+	 * @param string $block_content Rendered block content.
+	 * @return string Filtered block content.
 	 */
 	public static function restore_image_outer_container( $block_content ) {
 		if ( wp_theme_has_theme_json() ) {
@@ -1119,8 +1119,8 @@ class WP_Duotone_Gutenberg {
 	 * @since 6.3.0
 	 * @deprecated 6.3.0
 	 *
-	 * @param  array $preset Duotone preset value as seen in theme.json.
-	 * @return string        Duotone filter CSS id.
+	 * @param array $preset Duotone preset value as seen in theme.json.
+	 * @return string Duotone filter CSS id.
 	 */
 	public static function get_filter_id_from_preset( $preset ) {
 		_deprecated_function( __FUNCTION__, '6.3.0' );

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -652,7 +652,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * @since 7.1.0
 	 *
 	 * @param mixed $viewport_settings Viewport settings from theme.json.
-	 * @param array      $options           {
+	 * @param array $options           {
 	 *     Optional. Options for generating media queries.
 	 *
 	 *     @type bool $include_desktop Whether to include the desktop media query. Default false.
@@ -917,11 +917,11 @@ class WP_Theme_JSON_Gutenberg {
 	/**
 	 * Processes pseudo-selectors for any node (block or variation).
 	 *
-	 * @param array  $node The node data (block or variation).
-	 * @param string $base_selector The base selector.
-	 * @param array  $settings The theme settings.
-	 * @param string $block_name The block name.
-	 * @param array|null $block_metadata Metadata about the block to get styles for.
+	 * @param array      $node            The node data (block or variation).
+	 * @param string     $base_selector   The base selector.
+	 * @param array      $settings        The theme settings.
+	 * @param string     $block_name      The block name.
+	 * @param array|null $block_metadata  Metadata about the block to get styles for.
 	 * @param array|null $style_variation Style variation metadata.
 	 * @return array Array of pseudo-selector declarations.
 	 */
@@ -2111,7 +2111,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * Returns the global styles custom CSS for a single block.
 	 * This function is deprecated; please do not sync to core.
 	 *
-	 * @param array  $css The block css node.
+	 * @param array  $css      The block css node.
 	 * @param string $selector The block selector.
 	 *
 	 * @return string The global styles custom CSS for the block.
@@ -3005,13 +3005,13 @@ class WP_Theme_JSON_Gutenberg {
 	 * @since 6.6.0 Passing current theme JSON settings to wp_get_typography_font_size_value(). Using style engine to correctly fetch background CSS values.
 	 * @since 6.7.0 Allow ref resolution of background properties.
 	 *
-	 * @param array   $styles Styles to process.
-	 * @param array   $settings Theme settings.
-	 * @param array   $properties Properties metadata.
-	 * @param array   $theme_json Theme JSON array.
-	 * @param string  $selector The style block selector.
+	 * @param array   $styles           Styles to process.
+	 * @param array   $settings         Theme settings.
+	 * @param array   $properties       Properties metadata.
+	 * @param array   $theme_json       Theme JSON array.
+	 * @param string  $selector         The style block selector.
 	 * @param boolean $use_root_padding Whether to add custom properties at root level.
-	 * @return array  Returns the modified $declarations.
+	 * @return array Returns the modified $declarations.
 	 */
 	protected static function compute_style_properties( $styles, $settings = array(), $properties = null, $theme_json = null, $selector = null, $use_root_padding = null ) {
 		if ( empty( $styles ) ) {
@@ -3137,8 +3137,8 @@ class WP_Theme_JSON_Gutenberg {
 	 * @since 6.1.0 Added the `$theme_json` parameter.
 	 * @since 6.7.0 Added support for background image refs
 	 *
-	 * @param array $styles Styles subtree.
-	 * @param array $path   Which property to process.
+	 * @param array $styles     Styles subtree.
+	 * @param array $path       Which property to process.
 	 * @param array $theme_json Theme JSON array.
 	 * @return string|array Style property value.
 	 */
@@ -3512,7 +3512,7 @@ class WP_Theme_JSON_Gutenberg {
 	 *
 	 * @param array $theme_json The theme.json converted to an array.
 	 * @param array $selectors  Optional list of selectors per block.
-	 * @param array $options {
+	 * @param array $options    {
 	 *     Optional. An array of options for now used for internal purposes only (may change without notice).
 	 *
 	 *     @type bool $include_block_style_variations Includes nodes for block style variations. Default false.
@@ -4601,7 +4601,7 @@ class WP_Theme_JSON_Gutenberg {
 	 *
 	 * @since 5.9.0
 	 *
-	 * @param string $slug The slug we want to find a match from default presets.
+	 * @param string $slug      The slug we want to find a match from default presets.
 	 * @param array  $base_path The path to inspect. It's 'settings' by default.
 	 * @return string|null
 	 */
@@ -4651,8 +4651,8 @@ class WP_Theme_JSON_Gutenberg {
 	 * @since 6.6.0 Added support for block style variation element styles and $origin parameter.
 	 *
 	 * @param array  $theme_json Structure to sanitize.
-	 * @param string $origin    Optional. What source of data this object represents.
-	 *                          One of 'blocks', 'default', 'theme', or 'custom'. Default 'theme'.
+	 * @param string $origin     Optional. What source of data this object represents.
+	 *                           One of 'blocks', 'default', 'theme', or 'custom'. Default 'theme'.
 	 * @return array Sanitized structure.
 	 */
 	public static function remove_insecure_properties( $theme_json, $origin = 'theme' ) {
@@ -5741,7 +5741,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * It is recursive and modifies the input in-place.
 	 *
 	 * @since 6.3.0
-	 * @param array $tree   Input to process.
+	 * @param array $tree Input to process.
 	 * @return array The modified $tree.
 	 */
 	private static function resolve_custom_css_format( $tree ) {
@@ -5891,7 +5891,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * declarations instead of deriving it by subtracting the root selector from
 	 * the feature selector.
 	 *
-	 * @param array  $style_variation Style variation metadata.
+	 * @param array  $style_variation  Style variation metadata.
 	 * @param string $feature_selector CSS selector for the feature.
 	 * @return string Feature selector with block style variation selector added.
 	 */

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -224,7 +224,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 *              Added registration and merging of block style variations from partial theme.json files and the block styles registry.
 	 *
 	 * @param array $deprecated Deprecated. Not used.
-	 * @param array $options {
+	 * @param array $options    {
 	 *     Options arguments.
 	 *
 	 *     @type bool $with_supports Whether to include theme supports in the data. Default true.
@@ -927,7 +927,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 *
 	 * @since 6.6.0
 	 *
-	 * @param array $data   Array following the theme.json specification.
+	 * @param array $data       Array following the theme.json specification.
 	 * @param array $variations Shared block style variations.
 	 * @return array Theme json data including shared block style variation definitions.
 	 */
@@ -969,7 +969,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 *
 	 * @since 6.6.0
 	 *
-	 * @param array $data   Array following the theme.json specification.
+	 * @param array $data Array following the theme.json specification.
 	 * @return array Theme json data including variations from the block styles registry.
 	 */
 	private static function inject_variations_from_block_styles_registry( $data ) {

--- a/lib/class-wp-theme-json-schema-gutenberg.php
+++ b/lib/class-wp-theme-json-schema-gutenberg.php
@@ -105,7 +105,7 @@ class WP_Theme_JSON_Schema_Gutenberg {
 	 *
 	 * @since 6.6.0
 	 *
-	 * @param array $old     Data to migrate.
+	 * @param array  $old    Data to migrate.
 	 * @param string $origin What source of data this object represents.
 	 *                       One of 'blocks', 'default', 'theme', or 'custom'.
 	 * @return array Data with defaultFontSizes set to false.
@@ -219,7 +219,7 @@ class WP_Theme_JSON_Schema_Gutenberg {
 	 * @since 5.9.0
 	 *
 	 * @param array $settings Reference to the current settings array.
-	 * @param array $path Path to the property to be removed.
+	 * @param array $path     Path to the property to be removed.
 	 */
 	private static function unset_setting_by_path( &$settings, $path ) {
 		$tmp_settings = &$settings; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -26,9 +26,9 @@ function gutenberg_dir_path() {
  *
  * @since 0.1.0
  *
- * @param  string $path Relative path of the desired file.
+ * @param string $path Relative path of the desired file.
  *
- * @return string       Fully qualified URL pointing to the desired file.
+ * @return string Fully qualified URL pointing to the desired file.
  */
 function gutenberg_url( $path ) {
 	return plugins_url( $path, __DIR__ );

--- a/lib/compat/wordpress-7.0/template-activate.php
+++ b/lib/compat/wordpress-7.0/template-activate.php
@@ -232,8 +232,8 @@ function gutenberg_get_registered_block_templates( $query ) {
 	 *
 	 * @since 5.9.0
 	 *
-	 * @param WP_Block_Template[] $query_result Array of found block templates.
-	 * @param array               $query {
+	 * @param WP_Block_Template[] $query_result  Array of found block templates.
+	 * @param array               $query         {
 	 *     Arguments to retrieve templates. All arguments are optional.
 	 *
 	 *     @type string[] $slug__in  List of slugs to include.
@@ -827,8 +827,8 @@ function gutenberg_get_block_templates( $output, $query = array(), $template_typ
 	 *
 	 * @since 5.9.0
 	 *
-	 * @param WP_Block_Template[] $query_result Array of found block templates.
-	 * @param array               $query {
+	 * @param WP_Block_Template[] $query_result  Array of found block templates.
+	 * @param array               $query         {
 	 *     Arguments to retrieve templates. All arguments are optional.
 	 *
 	 *     @type string[] $slug__in  List of slugs to include.

--- a/lib/compat/wordpress-7.1/icons.php
+++ b/lib/compat/wordpress-7.1/icons.php
@@ -44,7 +44,7 @@ if ( ! function_exists( 'wp_register_icon' ) ) {
 	 *                          reserved for WordPress core icons; third-party code should
 	 *                          register icons under its own collection rather than the
 	 *                          "core" collection.
-	 * @param array  $args {
+	 * @param array  $args      {
 	 *     List of properties for the icon.
 	 *
 	 *     @type string $label     Required. A human-readable label for the icon.

--- a/lib/compat/wordpress-7.1/query-block.php
+++ b/lib/compat/wordpress-7.1/query-block.php
@@ -8,7 +8,7 @@
 /**
  * Filters the query loop block query vars to exclude the current post.
  *
- * @param array $query The current query vars.
+ * @param array    $query The current query vars.
  * @param WP_Block $block The block instance.
  *
  * @return array The modified query vars.

--- a/lib/experimental/kses.php
+++ b/lib/experimental/kses.php
@@ -79,7 +79,7 @@ if ( ! function_exists( 'allow_filter_in_styles' ) ) {
 	 *
 	 * This function should not be backported to core.
 	 *
-	 * @param bool   $allow_css Whether the CSS is allowed.
+	 * @param bool   $allow_css       Whether the CSS is allowed.
 	 * @param string $css_test_string The CSS to test.
 	 * @return bool Whether the CSS is allowed.
 	 */

--- a/lib/experimental/navigation-theme-opt-in.php
+++ b/lib/experimental/navigation-theme-opt-in.php
@@ -177,7 +177,7 @@ add_filter( 'wp_nav_menu_objects', 'gutenberg_remove_block_nav_menu_items', 10 )
  * Transformation depends on the menu item type. Link menu items are turned into
  * a `core/navigation-link` block. Block menu items are simply parsed.
  *
- * @param array $menu_items The menu items to convert, sorted by each menu item's menu order.
+ * @param array $menu_items              The menu items to convert, sorted by each menu item's menu order.
  * @param array $menu_items_by_parent_id All menu items, indexed by their parent's ID.
  *
  * @return array Updated menu items, sorted by each menu item's menu order.

--- a/lib/media/class-gutenberg-rest-attachments-controller.php
+++ b/lib/media/class-gutenberg-rest-attachments-controller.php
@@ -1756,8 +1756,8 @@ class Gutenberg_REST_Attachments_Controller extends WP_REST_Attachments_Controll
 	 * https://github.com/WordPress/wordpress-develop/pull/11856; until it lands
 	 * the function_exists() guard falls back to the inline implementation below.
 	 *
-	 * @param non-empty-string $mime_type The output image MIME type, e.g. 'image/jpeg'.
-	 * @param array{ width?: non-negative-int, height?: non-negative-int } $size Dimensions ('width', 'height') for the wp_editor_set_quality filter.
+	 * @param non-empty-string                                             $mime_type The output image MIME type, e.g. 'image/jpeg'.
+	 * @param array{ width?: non-negative-int, height?: non-negative-int } $size      Dimensions ('width', 'height') for the wp_editor_set_quality filter.
 	 * @return int<1, 100> Encode quality between 1 and 100.
 	 */
 	private function get_image_encode_quality( string $mime_type, array $size = array() ): int {


### PR DESCRIPTION
Part of a four-part split by area of the same docblock cleanup. This PR covers **`lib/`** (17 files, 70 changed lines).

## What?

Aligns the type, variable name, and description columns of `@param` tags in PHP docblocks under `lib/`, so they follow the [WordPress PHP documentation standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/).

## Why?

Columns across `@param` tags in the same docblock did not line up, and some lone tags carried stray padding (`@param  string $path`). The project's `phpcs.xml.dist` does not include `Squiz.Commenting.FunctionComment`, so CI never flagged any of it.

## How?

- Pads the type and `$var` columns to the widest entry within each docblock and normalises separators to a single space.
- Collapses stray padding on lone `@param` tags.
- Re-indents wrapped description lines to follow their new column.
- Removes `@return` padding left orphaned by the above, in the same docblocks.

Deliberately preserved: hash-notation bodies (`{ ... }`) keep their fixed four-space indent, and types containing spaces (`array<int, mixed>`) are kept as written.

This is the code that back-ports to WordPress Core, so it is split out from the `packages/` and test changes for a closer read.

## Testing Instructions

Comment-only change; no runtime behaviour is affected.

```bash
vendor/bin/phpcs -s --standard=WordPress-Docs \
  --sniffs=Squiz.Commenting.FunctionComment $(git diff --name-only trunk)
```

Verified on this branch in isolation:

| Check | Result |
|---|---|
| `WordPress-Docs` param-alignment sniffs | 0 violations |
| `vendor/bin/phpcs` (project ruleset) | 0 errors |
| `php -l` on all 17 files | clean |
| `git diff --check` | clean |

## Note

No `CHANGELOG.md` entries added — these are docblock comments, not production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)