### PR TITLE
Docs: Align @param tag columns in packages/ docblocks

### DIFF
--- a/packages/block-library/src/accordion-item/index.php
+++ b/packages/block-library/src/accordion-item/index.php
@@ -7,7 +7,7 @@
  * @since 6.9.0
  *
  * @param array{ openByDefault: bool } $attributes The block attributes.
- * @param string                        $content   The block content.
+ * @param string                       $content    The block content.
  * @return string Returns the updated markup.
  */
 function block_core_accordion_item_render( array $attributes, string $content ): string {

--- a/packages/block-library/src/accordion/index.php
+++ b/packages/block-library/src/accordion/index.php
@@ -5,8 +5,8 @@
  * @package WordPress
  * @since 6.9.0
  *
- * @param array $attributes The block attributes.
- * @param string $content The block content.
+ * @param array  $attributes The block attributes.
+ * @param string $content    The block content.
  *
  * @return string Returns the updated markup.
  */

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -298,7 +298,7 @@ function block_core_breadcrumbs_get_post_title( $post_id_or_object ) {
  *
  * @since 7.0.0
  *
- * @param int    $post_id   The post ID.
+ * @param int $post_id The post ID.
  *
  * @return array Array of breadcrumb item data.
  */
@@ -524,7 +524,7 @@ function block_core_breadcrumbs_get_terms_breadcrumbs( $post_id, $post_type ) {
 	 *
 	 * @since 7.0.0
 	 *
-	 * @param array  $settings {
+	 * @param array  $settings  {
 	 *     Array of breadcrumb settings. Default empty array.
 	 *
 	 *     @type string $taxonomy Optional. Taxonomy slug to use for breadcrumbs.

--- a/packages/block-library/src/form-input/index.php
+++ b/packages/block-library/src/form-input/index.php
@@ -9,7 +9,7 @@
  * Renders the `core/form-input` block on server.
  *
  * @param array  $attributes The block attributes.
- * @param string $content The saved content.
+ * @param string $content    The saved content.
  *
  * @return string The content of the block being rendered.
  */

--- a/packages/block-library/src/form-submission-notification/index.php
+++ b/packages/block-library/src/form-submission-notification/index.php
@@ -9,7 +9,7 @@
  * Renders the `core/form-submission-notification` block on server.
  *
  * @param array  $attributes The block attributes.
- * @param string $content The saved content.
+ * @param string $content    The saved content.
  *
  * @return string The content of the block being rendered.
  */

--- a/packages/block-library/src/form/index.php
+++ b/packages/block-library/src/form/index.php
@@ -9,7 +9,7 @@
  * Renders the `core/form` block on server.
  *
  * @param array  $attributes The block attributes.
- * @param string $content The saved content.
+ * @param string $content    The saved content.
  *
  * @return string The content of the block being rendered.
  */

--- a/packages/block-library/src/heading/index.php
+++ b/packages/block-library/src/heading/index.php
@@ -17,7 +17,7 @@
  * @since 6.2.0
  *
  * @param array  $attributes Attributes of the block being rendered.
- * @param string $content Content of the block being rendered.
+ * @param string $content    Content of the block being rendered.
  *
  * @return string The content of the block being rendered.
  */

--- a/packages/block-library/src/home-link/index.php
+++ b/packages/block-library/src/home-link/index.php
@@ -11,7 +11,7 @@
  *
  * @since 6.0.0
  *
- * @param  array $context home link block context.
+ * @param array $context home link block context.
  * @return array Colors CSS classes and inline styles.
  */
 function block_core_home_link_build_css_colors( $context ) {
@@ -64,7 +64,7 @@ function block_core_home_link_build_css_colors( $context ) {
  *
  * @since 6.0.0
  *
- * @param  array $context    Home link block context.
+ * @param array $context Home link block context.
  * @return string The li wrapper attributes.
  */
 function block_core_home_link_build_li_wrapper_attributes( $context ) {

--- a/packages/block-library/src/list/index.php
+++ b/packages/block-library/src/list/index.php
@@ -15,7 +15,7 @@
  * @see https://github.com/WordPress/gutenberg/issues/12420
  *
  * @param array  $attributes Attributes of the block being rendered.
- * @param string $content Content of the block being rendered.
+ * @param string $content    Content of the block being rendered.
  *
  * @return string The content of the block being rendered.
  */

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -90,7 +90,7 @@ function block_core_navigation_link_build_css_colors( $context, $attributes, $is
  * @since 5.9.0
  * @deprecated 7.0.0
  *
- * @param  array $context Navigation block context.
+ * @param array $context Navigation block context.
  * @return array Font size CSS classes and inline styles.
  */
 function block_core_navigation_link_build_css_font_sizes( $context ) {
@@ -308,7 +308,7 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
  * @since 5.9.0
  *
  * @param WP_Taxonomy|WP_Post_Type $entity post type or taxonomy entity.
- * @param string                   $kind string of value 'taxonomy' or 'post-type'.
+ * @param string                   $kind   string of value 'taxonomy' or 'post-type'.
  *
  * @return array
  */

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -411,7 +411,7 @@ class WP_Navigation_Block_Renderer {
 	 * @since 6.5.0
 	 *
 	 * @param string $overlay_template_part_id The overlay template part ID in format "theme//slug".
-	 * @param array  $attributes                The block attributes.
+	 * @param array  $attributes               The block attributes.
 	 * @return WP_Block_List Returns the inner blocks for the overlay template part.
 	 */
 	private static function get_overlay_blocks_from_template_part( $overlay_template_part_id, $attributes ) {
@@ -512,7 +512,7 @@ class WP_Navigation_Block_Renderer {
 	 * @since 6.5.0
 	 *
 	 * @param array    $attributes The block attributes.
-	 * @param WP_Block $block The parsed block.
+	 * @param WP_Block $block      The parsed block.
 	 * @return WP_Block_List Returns the inner blocks for the navigation block.
 	 */
 	private static function get_inner_blocks( $attributes, $block ) {
@@ -734,8 +734,8 @@ class WP_Navigation_Block_Renderer {
 	 *
 	 * @since 6.5.0
 	 *
-	 * @param array         $attributes The block attributes.
-	 * @param WP_Block_List $inner_blocks The list of inner blocks.
+	 * @param array         $attributes        The block attributes.
+	 * @param WP_Block_List $inner_blocks      The list of inner blocks.
 	 * @param string        $inner_blocks_html The markup for the inner blocks.
 	 * @return string Returns the container markup.
 	 */
@@ -973,7 +973,7 @@ class WP_Navigation_Block_Renderer {
 	 *
 	 * @since 6.5.0
 	 *
-	 * @param array         $attributes The block attributes.
+	 * @param array         $attributes   The block attributes.
 	 * @param WP_Block_List $inner_blocks The list of inner blocks.
 	 * @return string Returns the navigation wrapper markup.
 	 */
@@ -1885,7 +1885,7 @@ function block_core_navigation_get_classic_menu_fallback() {
  *
  * @deprecated 6.3.0 Use WP_Navigation_Fallback::get_classic_menu_fallback_blocks() instead.
  *
- * @param  object $classic_nav_menu WP_Term The classic navigation object to convert.
+ * @param object $classic_nav_menu WP_Term The classic navigation object to convert.
  * @return array the normalized parsed blocks.
  */
 function block_core_navigation_get_classic_menu_fallback_blocks( $classic_nav_menu ) {

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -128,14 +128,14 @@ function block_core_page_list_build_css_colors( $attributes, $context ) {
  *
  * @since 5.8.0
  *
- * @param string  $submenu_visibility The submenu visibility mode: 'hover', 'click', or 'always'.
- * @param boolean $show_submenu_icons Whether to show submenu indicator icons.
- * @param boolean $is_navigation_child If block is a child of Navigation block.
- * @param array   $nested_pages The array of nested pages.
- * @param boolean $is_nested Whether the submenu is nested or not.
+ * @param string  $submenu_visibility       The submenu visibility mode: 'hover', 'click', or 'always'.
+ * @param boolean $show_submenu_icons       Whether to show submenu indicator icons.
+ * @param boolean $is_navigation_child      If block is a child of Navigation block.
+ * @param array   $nested_pages             The array of nested pages.
+ * @param boolean $is_nested                Whether the submenu is nested or not.
  * @param array   $active_page_ancestor_ids An array of ancestor ids for active page.
- * @param array   $colors Color information for overlay styles.
- * @param integer $depth The nesting depth.
+ * @param array   $colors                   Color information for overlay styles.
+ * @param integer $depth                    The nesting depth.
  *
  * @return string List markup.
  */
@@ -227,7 +227,7 @@ function block_core_page_list_render_nested_page_list( $submenu_visibility, $sho
  * @since 5.8.0
  *
  * @param array $current_level The level being iterated through.
- * @param array $children The children grouped by parent post ID.
+ * @param array $children      The children grouped by parent post ID.
  *
  * @return array The nested array of pages.
  */

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -360,7 +360,7 @@ function apply_block_core_search_border_styles( $attributes, $property, &$wrappe
  *
  * @since 5.8.0
  *
- * @param  array $attributes The block attributes.
+ * @param array $attributes The block attributes.
  *
  * @return array Style HTML attribute.
  */

--- a/packages/block-library/src/site-logo/index.php
+++ b/packages/block-library/src/site-logo/index.php
@@ -139,7 +139,7 @@ add_filter( 'theme_mod_custom_logo', '_override_custom_logo_theme_mod' );
  *
  * @since 5.8.0
  *
- * @param  mixed $value Attachment ID of the custom logo or an empty value.
+ * @param mixed $value Attachment ID of the custom logo or an empty value.
  * @return mixed
  */
 function _sync_custom_logo_to_site_logo( $value ) {

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -138,7 +138,7 @@ function block_core_social_link_get_name( $service ) {
  * @since 5.4.0
  *
  * @param string $service The service slug to extract data from.
- * @param string $field The field ('name', 'icon', etc) to extract for a service.
+ * @param string $field   The field ('name', 'icon', etc) to extract for a service.
  *
  * @return array|string
  */

--- a/packages/block-library/src/table-of-contents/index.php
+++ b/packages/block-library/src/table-of-contents/index.php
@@ -14,7 +14,7 @@ const BLOCK_CORE_TABLE_OF_CONTENTS_DEFAULT_HEADING_LEVEL = 2;
  * Adds an aria-label to the table of contents block content.
  *
  * @param array  $attributes Attributes of the block being rendered.
- * @param string $content Content of the block being rendered.
+ * @param string $content    Content of the block being rendered.
  *
  * @return string The content of the block being rendered.
  */
@@ -364,8 +364,8 @@ function block_core_table_of_contents_build_list_items( $nested_headings, $list_
  * Renders the table of contents block from current post headings.
  *
  * @param array         $attributes Attributes of the block being rendered.
- * @param string        $content Content of the block being rendered.
- * @param WP_Block|null $block Block instance.
+ * @param string        $content    Content of the block being rendered.
+ * @param WP_Block|null $block      Block instance.
  *
  * @return string The content of the block being rendered.
  */

--- a/packages/e2e-tests/plugins/class-test-widget.php
+++ b/packages/e2e-tests/plugins/class-test-widget.php
@@ -25,7 +25,7 @@ class Test_Widget extends WP_Widget {
 	/**
 	 * Outputs the content for the widget instance.
 	 *
-	 * @param array $args Display arguments including 'before_title', 'after_title',
+	 * @param array $args     Display arguments including 'before_title', 'after_title',
 	 *                        'before_widget', and 'after_widget'.
 	 * @param array $instance Settings for the current Block widget instance.
 	 */

--- a/packages/style-engine/src/class-wp-style-engine-processor.php
+++ b/packages/style-engine/src/class-wp-style-engine-processor.php
@@ -97,7 +97,7 @@ if ( ! class_exists( 'WP_Style_Engine_Processor' ) ) {
 		 *
 		 * Since 6.4.0 Optimization is no longer the default.
 		 *
-		 * @param array $options   {
+		 * @param array $options {
 		 *     Optional. An array of options. Default empty array.
 		 *
 		 *     @type bool $optimize Whether to optimize the CSS output, e.g., combine rules. Default is `false`.

--- a/packages/style-engine/src/class-wp-style-engine.php
+++ b/packages/style-engine/src/class-wp-style-engine.php
@@ -404,7 +404,7 @@ if ( ! class_exists( 'WP_Style_Engine' ) ) {
 		/**
 		 * Util: Checks whether an incoming block style value is valid.
 		 *
-		 * @param string? $style_value  A single css preset value.
+		 * @param string? $style_value A single css preset value.
 		 *
 		 * @return bool
 		 */
@@ -415,11 +415,11 @@ if ( ! class_exists( 'WP_Style_Engine' ) ) {
 		/**
 		 * Stores a CSS rule using the provided CSS selector and CSS declarations.
 		 *
-		 * @param string   $store_name       A valid store key.
-		 * @param string   $css_selector     When a selector is passed, the function will return a full CSS rule `$selector { ...rules }`, otherwise a concatenated string of properties and values.
+		 * @param string                                    $store_name       A valid store key.
+		 * @param string                                    $css_selector     When a selector is passed, the function will return a full CSS rule `$selector { ...rules }`, otherwise a concatenated string of properties and values.
 		 * @param string[]|WP_Style_Engine_CSS_Declarations $css_declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ),
-		 *                                                                     or a WP_Style_Engine_CSS_Declarations object.
-		 * @param string   $rules_group        Optional. A parent CSS selector in the case of nested CSS, or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
+		 *                                                                    or a WP_Style_Engine_CSS_Declarations object.
+		 * @param string                                    $rules_group      Optional. A parent CSS selector in the case of nested CSS, or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
 		 *
 		 * @return void.
 		 */

--- a/packages/style-engine/src/style-engine.php
+++ b/packages/style-engine/src/style-engine.php
@@ -22,7 +22,7 @@
  * @since 6.1.0
  *
  * @param array $block_styles The style object.
- * @param array $options {
+ * @param array $options      {
  *     Optional. An array of options. Default empty array.
  *
  *     @type string|null $context                    An identifier describing the origin of the style object, e.g., 'block-supports' or 'global-styles'. Default is `null`.
@@ -89,7 +89,7 @@ function wp_style_engine_get_styles( $block_styles, $options = array() ) {
  *                                                                       or a WP_Style_Engine_CSS_Declarations object.
  *     }
  * }
- * @param array $options {
+ * @param array $options   {
  *     Optional. An array of options. Default empty array.
  *
  *     @type string|null $context  An identifier describing the origin of the style object, e.g., 'block-supports' or 'global-styles'. Default is 'block-supports'.

--- a/packages/widgets/src/blocks/widget-group/index.php
+++ b/packages/widgets/src/blocks/widget-group/index.php
@@ -14,8 +14,8 @@
  * @global int|string $_sidebar_being_rendered
  *
  * @param array    $attributes The block attributes.
- * @param string   $content The block content.
- * @param WP_Block $block The block.
+ * @param string   $content    The block content.
+ * @param WP_Block $block      The block.
  *
  * @return string Rendered block.
  */
@@ -70,7 +70,7 @@ add_action( 'init', 'register_block_core_widget_group' );
  *
  * @global int|string $_sidebar_being_rendered
  *
- * @param int|string $index       Index, name, or ID of the dynamic sidebar.
+ * @param int|string $index Index, name, or ID of the dynamic sidebar.
  */
 function note_sidebar_being_rendered( $index ) {
 	global $_sidebar_being_rendered;


### PR DESCRIPTION
Part of a four-part split by area of the same docblock cleanup. This PR covers **`packages/`** (21 files, 46 changed lines).

## What?

Aligns the type, variable name, and description columns of `@param` tags in PHP docblocks under `packages/`, so they follow the [WordPress PHP documentation standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/).

## Why?

Columns across `@param` tags in the same docblock did not line up, and some lone tags carried stray padding (`@param  string $path`). The project's `phpcs.xml.dist` does not include `Squiz.Commenting.FunctionComment`, so CI never flagged any of it.

## How?

- Pads the type and `$var` columns to the widest entry within each docblock and normalises separators to a single space.
- Collapses stray padding on lone `@param` tags.
- Re-indents wrapped description lines to follow their new column.
- Removes `@return` padding left orphaned by the above, in the same docblocks.

Deliberately preserved: hash-notation bodies (`{ ... }`) keep their fixed four-space indent, and types containing spaces (`array<int, mixed>`) are kept as written.

Covers `block-library`, `style-engine`, `widgets`, and `e2e-tests` plugin fixtures.

## Testing Instructions

Comment-only change; no runtime behaviour is affected.

```bash
vendor/bin/phpcs -s --standard=WordPress-Docs \
  --sniffs=Squiz.Commenting.FunctionComment $(git diff --name-only trunk)
```

Verified on this branch in isolation:

| Check | Result |
|---|---|
| `WordPress-Docs` param-alignment sniffs | 0 violations |
| `vendor/bin/phpcs` (project ruleset) | 0 errors |
| `php -l` on all 21 files | clean |
| `git diff --check` | clean |

## Note

No `CHANGELOG.md` entries added — these are docblock comments, not production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)