### PR TITLE
Docs: Align @param tag columns in phpunit/ docblocks

### DIFF
--- a/phpunit/block-supports/aria-label-test.php
+++ b/phpunit/block-supports/aria-label-test.php
@@ -48,8 +48,8 @@ class WP_Block_Supports_Aria_Label_Test extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_aria_label_block_support
 	 *
-	 * @param boolean|array $support Aria label block support configuration.
-	 * @param string        $value   Aria label value for attribute object.
+	 * @param boolean|array $support  Aria label block support configuration.
+	 * @param string        $value    Aria label value for attribute object.
 	 * @param array         $expected Expected aria-label attributes.
 	 */
 	public function test_gutenberg_apply_aria_label_support( $support, $value, $expected ) {

--- a/phpunit/block-supports/shadow-test.php
+++ b/phpunit/block-supports/shadow-test.php
@@ -55,9 +55,9 @@ class WP_Block_Supports_Shadow_Test extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_generate_shadow_fixtures
 	 *
-	 * @param boolean|array $support Shadow block support configuration.
-	 * @param string        $value   Shadow style value for style attribute object.
-	 * @param array         $expected       Expected shadow block support styles.
+	 * @param boolean|array $support  Shadow block support configuration.
+	 * @param string        $value    Shadow style value for style attribute object.
+	 * @param array         $expected Expected shadow block support styles.
 	 */
 	public function test_gutenberg_apply_shadow_support( $support, $value, $expected ) {
 		$block_type  = self::register_shadow_block_with_support(

--- a/phpunit/block-supports/states-test.php
+++ b/phpunit/block-supports/states-test.php
@@ -63,8 +63,8 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 	 * to produce the unique scoped class name for a given map of state => style arrays.
 	 * CSS is now registered with the style engine store rather than injected inline.
 	 *
-	 * @param array $state_styles Map of state to style array (e.g. `[':hover' => ['color' => [...]]]`).
-	 * @param string $block_name  Block name.
+	 * @param array  $state_styles Map of state to style array (e.g. `[':hover' => ['color' => [...]]]`).
+	 * @param string $block_name   Block name.
 	 * @return array { unique_class: string }
 	 */
 	private function build_expected_state_output( $state_styles, $block_name = 'core/navigation-link' ) {

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -292,7 +292,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_generate_font_size_preset_fixtures
 	 *
-	 * @param array  $font_size                     {
+	 * @param array  $font_size       {
 	 *     Required. A font size as represented in the fontSizes preset format as seen in theme.json.
 	 *
 	 *     @type string $name Name of the font size preset.
@@ -810,7 +810,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_generate_font_size_preset_should_use_fluid_typography_deprecated_fixtures
 	 *
-	 * @param array  $font_size                     {
+	 * @param array  $font_size                   {
 	 *     Required. A font size as represented in the fontSizes preset format as seen in theme.json.
 	 *
 	 *     @type string $name Name of the font size preset.
@@ -818,7 +818,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	 *     @type string $size CSS font-size value, including units where applicable.
 	 * }
 	 * @param bool   $should_use_fluid_typography An override to switch fluid typography "on". Can be used for unit testing.
-	 * @param string $expected_output Expected output of gutenberg_get_typography_font_size_value().
+	 * @param string $expected_output             Expected output of gutenberg_get_typography_font_size_value().
 	 */
 	public function test_gutenberg_get_typography_font_size_value_should_use_fluid_typography_deprecated( $font_size, $should_use_fluid_typography, $expected_output ) {
 		$actual = gutenberg_get_typography_font_size_value( $font_size, $should_use_fluid_typography );
@@ -858,7 +858,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_generate_should_override_theme_settings_fixtures
 	 *
-	 * @param array  $font_size                     {
+	 * @param array  $font_size       {
 	 *     Required. A font size as represented in the fontSizes preset format as seen in theme.json.
 	 *
 	 *     @type string $name Name of the font size preset.
@@ -1241,7 +1241,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_get_computed_fluid_typography_value
 	 *
-	 * @param array  $args {
+	 * @param array  $args            {
 	 *      Optional. An associative array of values to calculate a fluid formula for font size. Default is empty array.
 	 *
 	 *     @type string $maximum_viewport_width Maximum size up to which type will have fluidity.
@@ -1250,7 +1250,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	 *     @type string $minimum_font_size      Minimum font size for any clamp() calculation.
 	 *     @type int    $scale_factor           A scale factor to determine how fast a font scales within boundaries.
 	 * }
-	 * @param string $expected_output             Expected value of style property from gutenberg_apply_typography_support().
+	 * @param string $expected_output Expected value of style property from gutenberg_apply_typography_support().
 	 */
 	public function test_get_computed_fluid_typography_value( $args, $expected_output ) {
 		$actual = gutenberg_get_computed_fluid_typography_value( $args );

--- a/phpunit/blocks/block-navigation-link-variations-test.php
+++ b/phpunit/blocks/block-navigation-link-variations-test.php
@@ -244,7 +244,7 @@ class Block_Navigation_Link_Variations_Test extends WP_UnitTestCase {
 	 * Get a variation by its name from an array of variations.
 	 *
 	 * @param string $variation_name The name (= slug) of the variation.
-	 * @param array  $variations An array of variations.
+	 * @param array  $variations     An array of variations.
 	 * @return array|null The found variation or null.
 	 */
 	private function get_variation_by_name( $variation_name, $variations ) {

--- a/phpunit/class-wp-theme-json-selector-list.php
+++ b/phpunit/class-wp-theme-json-selector-list.php
@@ -12,7 +12,7 @@ class WP_Theme_JSON_Gutenberg_Selector_List_Test extends WP_UnitTestCase {
 	 * Invokes a protected static method on WP_Theme_JSON_Gutenberg.
 	 *
 	 * @param string $method_name Method name.
-	 * @param mixed ...$args Method arguments.
+	 * @param mixed  ...$args     Method arguments.
 	 * @return mixed Method result.
 	 */
 	private static function invoke_theme_json_method( $method_name, ...$args ) {
@@ -29,7 +29,7 @@ class WP_Theme_JSON_Gutenberg_Selector_List_Test extends WP_UnitTestCase {
 	/**
 	 * @dataProvider data_split_selector_list
 	 *
-	 * @param string $selector CSS selector list.
+	 * @param string   $selector CSS selector list.
 	 * @param string[] $expected Expected selectors.
 	 */
 	public function test_split_selector_list( $selector, $expected ) {

--- a/phpunit/notes-mentions-test.php
+++ b/phpunit/notes-mentions-test.php
@@ -80,8 +80,8 @@ class Tests_Notes_Mentions extends WP_UnitTestCase {
 	/**
 	 * Records wp_mail() calls and short-circuits delivery.
 	 *
-	 * @param null                                              $short_circuit Short-circuit value.
-	 * @param array{ to: string|string[], subject: string, message: string } $atts wp_mail() arguments.
+	 * @param null                                                           $short_circuit Short-circuit value.
+	 * @param array{ to: string|string[], subject: string, message: string } $atts          wp_mail() arguments.
 	 * @return bool Always true to indicate a "sent" message.
 	 */
 	public function capture_mail( $short_circuit, $atts ): bool {


### PR DESCRIPTION
Part of a four-part split by area of the same docblock cleanup. This PR covers **`phpunit/`** (7 files, 18 changed lines).

## What?

Aligns the type, variable name, and description columns of `@param` tags in PHP docblocks under `phpunit/`, so they follow the [WordPress PHP documentation standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/).

## Why?

Columns across `@param` tags in the same docblock did not line up, and some lone tags carried stray padding (`@param  string $path`). The project's `phpcs.xml.dist` does not include `Squiz.Commenting.FunctionComment`, so CI never flagged any of it.

## How?

- Pads the type and `$var` columns to the widest entry within each docblock and normalises separators to a single space.
- Collapses stray padding on lone `@param` tags.
- Re-indents wrapped description lines to follow their new column.
- Removes `@return` padding left orphaned by the above, in the same docblocks.

Deliberately preserved: hash-notation bodies (`{ ... }`) keep their fixed four-space indent, and types containing spaces (`array<int, mixed>`) are kept as written.

Test-only docblocks.

## Testing Instructions

Comment-only change; no runtime behaviour is affected.

```bash
vendor/bin/phpcs -s --standard=WordPress-Docs \
  --sniffs=Squiz.Commenting.FunctionComment $(git diff --name-only trunk)
```

Verified on this branch in isolation:

| Check | Result |
|---|---|
| `WordPress-Docs` param-alignment sniffs | 0 violations |
| `vendor/bin/phpcs` (project ruleset) | 0 errors |
| `php -l` on all 7 files | clean |
| `git diff --check` | clean |

## Note

No `CHANGELOG.md` entries added — these are docblock comments, not production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)