### PR TITLE
Docs: Align @param tag columns in test/ docblocks

### DIFF
--- a/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/CodeAnalysis/ForbiddenFunctionsAndClassesSniff.php
+++ b/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/CodeAnalysis/ForbiddenFunctionsAndClassesSniff.php
@@ -65,8 +65,8 @@ final class ForbiddenFunctionsAndClassesSniff implements Sniff {
 	 * Detects whether a given string token represents a function call or class usage.
 	 * It then delegates further processing based on the type of usage detected.
 	 *
-	 * @param File $phpcs_file The file being scanned.
-	 * @param int  $stack_pointer  The position of the current token in the token stack.
+	 * @param File $phpcs_file    The file being scanned.
+	 * @param int  $stack_pointer The position of the current token in the token stack.
 	 */
 	private function process_string_token( File $phpcs_file, $stack_pointer ) {
 		if ( empty( $this->forbidden_functions ) && empty( $this->forbidden_classes ) ) {


### PR DESCRIPTION
Part of a four-part split by area of the same docblock cleanup. This PR covers **`test/`** (1 files, 2 changed lines).

## What?

Aligns the type, variable name, and description columns of `@param` tags in PHP docblocks under `test/`, so they follow the [WordPress PHP documentation standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/).

## Why?

Columns across `@param` tags in the same docblock did not line up, and some lone tags carried stray padding (`@param  string $path`). The project's `phpcs.xml.dist` does not include `Squiz.Commenting.FunctionComment`, so CI never flagged any of it.

## How?

- Pads the type and `$var` columns to the widest entry within each docblock and normalises separators to a single space.
- Collapses stray padding on lone `@param` tags.
- Re-indents wrapped description lines to follow their new column.
- Removes `@return` padding left orphaned by the above, in the same docblocks.

Deliberately preserved: hash-notation bodies (`{ ... }`) keep their fixed four-space indent, and types containing spaces (`array<int, mixed>`) are kept as written.

Single sniff fixture under `test/php/gutenberg-coding-standards/`. Small enough to fold into the `phpunit/` PR if preferred.

## Testing Instructions

Comment-only change; no runtime behaviour is affected.

```bash
vendor/bin/phpcs -s --standard=WordPress-Docs \
  --sniffs=Squiz.Commenting.FunctionComment $(git diff --name-only trunk)
```

Verified on this branch in isolation:

| Check | Result |
|---|---|
| `WordPress-Docs` param-alignment sniffs | 0 violations |
| `vendor/bin/phpcs` (project ruleset) | 0 errors |
| `php -l` on all 1 files | clean |
| `git diff --check` | clean |

## Note

No `CHANGELOG.md` entries added — these are docblock comments, not production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)